### PR TITLE
Use MathF for .Net Core 2.0

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -14,7 +14,7 @@ if not "%GitVersion_NuGetVersion%" == "" (
 )
 if not "%errorlevel%"=="0" goto failure
 
-dotnet test ./tests/SixLabors.Core.Tests/SixLabors.Primitives.Tests.csproj
+dotnet test ./tests/SixLabors.Core.Tests/SixLabors.Core.Tests.csproj
 
 
 if not "%GitVersion_NuGetVersion%" == "" (

--- a/src/SixLabors.Core/MathF.cs
+++ b/src/SixLabors.Core/MathF.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
+#if !NETCOREAPP2_0
 using System.Runtime.CompilerServices;
 
-namespace SixLabors
+namespace System
 {
     /// <summary>
     /// Provides single-precision floating point constants and static methods for trigonometric, logarithmic, and other common mathematical functions.
     /// </summary>
+    /// <remarks>MathF emulation on platforms that don't support it natively.</remarks>
     // ReSharper disable InconsistentNaming
     internal static class MathF
     {
@@ -82,19 +83,6 @@ namespace SixLabors
         public static float Cos(float f)
         {
             return (float)Math.Cos(f);
-        }
-
-        /// <summary>
-        /// Converts a degree (360-periodic) angle to a radian (2*Pi-periodic) angle.
-        /// </summary>
-        /// <param name="degree">The angle in degrees.</param>
-        /// <returns>
-        /// The <see cref="float"/> representing the degree as radians.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float ToRadians(float degree)
-        {
-            return degree * (PI / 180F);
         }
 
         /// <summary>
@@ -172,19 +160,6 @@ namespace SixLabors
         }
 
         /// <summary>
-        /// Converts a radian (2*Pi-periodic) angle to a degree (360-periodic) angle.
-        /// </summary>
-        /// <param name="radian">The angle in radians.</param>
-        /// <returns>
-        /// The <see cref="float"/> representing the degree as radians.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float ToDegree(float radian)
-        {
-            return radian / (PI / 180F);
-        }
-
-        /// <summary>
         /// Rounds a single-precision floating-point value to the nearest integral value.
         /// </summary>
         /// <param name="f">A single-precision floating-point number to be rounded.</param>
@@ -234,26 +209,6 @@ namespace SixLabors
         }
 
         /// <summary>
-        /// Returns the result of a normalized sine cardinal function for the given value.
-        /// SinC(x) = sin(pi*x)/(pi*x).
-        /// </summary>
-        /// <param name="f">A single-precision floating-point number to calculate the result for.</param>
-        /// <returns>
-        /// The sine cardinal of <paramref name="f" />.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float SinC(float f)
-        {
-            if (Abs(f) > Constants.Epsilon)
-            {
-                f *= PI;
-                return Clean(Sin(f) / f);
-            }
-
-            return 1F;
-        }
-
-        /// <summary>
         /// Returns the square root of a specified number.
         /// </summary>
         /// <param name="f">The number whose square root is to be found.</param>
@@ -269,23 +224,6 @@ namespace SixLabors
         {
             return (float)Math.Sqrt(f);
         }
-
-        /// <summary>
-        /// Ensures that any passed float is correctly rounded to zero
-        /// </summary>
-        /// <param name="x">The value to clean.</param>
-        /// <returns>
-        /// The <see cref="float"/>
-        /// </returns>.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static float Clean(float x)
-        {
-            if (Abs(x) < Constants.Epsilon)
-            {
-                return 0F;
-            }
-
-            return x;
-        }
     }
 }
+#endif

--- a/src/SixLabors.Core/MathF.cs
+++ b/src/SixLabors.Core/MathF.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-#if !NETCOREAPP2_0
 using System.Runtime.CompilerServices;
 
+#if NETCOREAPP2_0
+[assembly: TypeForwardedTo(typeof(System.MathF))]
+#else
 namespace System
 {
     /// <summary>

--- a/src/SixLabors.Core/MathFExtensions.cs
+++ b/src/SixLabors.Core/MathFExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace SixLabors
+{
+    /// <summary>
+    /// Provides common mathematical methods.
+    /// </summary>
+    internal static class MathFExtensions
+    {
+        /// <summary>
+        /// Converts a degree (360-periodic) angle to a radian (2*Pi-periodic) angle.
+        /// </summary>
+        /// <param name="degree">The angle in degrees.</param>
+        /// <returns>
+        /// The <see cref="float"/> representing the degree as radians.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DegreeToRadian(float degree)
+        {
+            return degree * (MathF.PI / 180F);
+        }
+
+        /// <summary>
+        /// Converts a radian (2*Pi-periodic) angle to a degree (360-periodic) angle.
+        /// </summary>
+        /// <param name="radian">The angle in radians.</param>
+        /// <returns>
+        /// The <see cref="float"/> representing the degree as radians.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float RadianToDegree(float radian)
+        {
+            return radian / (MathF.PI / 180F);
+        }
+    }
+}

--- a/src/SixLabors.Core/Primitives/Matrix3x2Extensions.cs
+++ b/src/SixLabors.Core/Primitives/Matrix3x2Extensions.cs
@@ -50,12 +50,12 @@ namespace SixLabors.Primitives
         public static Matrix3x2 CreateScale(float scale, PointF centerPoint) => Matrix3x2.CreateScale(scale, centerPoint);
 
         /// <summary>
-        /// Creates a skew matrix from the given angles in radians.
+        /// Creates a skew matrix from the given angles in degrees.
         /// </summary>
         /// <param name="degreesX">The X angle, in degrees.</param>
         /// <param name="degreesY">The Y angle, in degrees.</param>
         /// <returns>A skew matrix.</returns>
-        public static Matrix3x2 CreateSkewDegrees(float degreesX, float degreesY) => Matrix3x2.CreateSkew(MathF.ToRadians(degreesX), MathF.ToRadians(degreesY));
+        public static Matrix3x2 CreateSkewDegrees(float degreesX, float degreesY) => Matrix3x2.CreateSkew(MathFExtensions.DegreeToRadian(degreesX), MathFExtensions.DegreeToRadian(degreesY));
 
         /// <summary>
         /// Creates a skew matrix from the given angles in radians and a center point.
@@ -67,20 +67,20 @@ namespace SixLabors.Primitives
         public static Matrix3x2 CreateSkew(float radiansX, float radiansY, PointF centerPoint) => Matrix3x2.CreateSkew(radiansX, radiansY, centerPoint);
 
         /// <summary>
-        /// Creates a skew matrix from the given angles in radians and a center point.
+        /// Creates a skew matrix from the given angles in degrees and a center point.
         /// </summary>
         /// <param name="degreesX">The X angle, in degrees.</param>
         /// <param name="degreesY">The Y angle, in degrees.</param>
         /// <param name="centerPoint">The center point.</param>
         /// <returns>A skew matrix.</returns>
-        public static Matrix3x2 CreateSkewDegrees(float degreesX, float degreesY, PointF centerPoint) => Matrix3x2.CreateSkew(MathF.ToRadians(degreesX), MathF.ToRadians(degreesY), centerPoint);
+        public static Matrix3x2 CreateSkewDegrees(float degreesX, float degreesY, PointF centerPoint) => Matrix3x2.CreateSkew(MathFExtensions.DegreeToRadian(degreesX), MathFExtensions.DegreeToRadian(degreesY), centerPoint);
 
         /// <summary>
-        /// Creates a rotation matrix using the given rotation in radians.
+        /// Creates a rotation matrix using the given rotation in degrees.
         /// </summary>
         /// <param name="degrees">The amount of rotation, in degrees.</param>
         /// <returns>A rotation matrix.</returns>
-        public static Matrix3x2 CreateRotationDegrees(float degrees) => Matrix3x2.CreateRotation(MathF.ToRadians(degrees));
+        public static Matrix3x2 CreateRotationDegrees(float degrees) => Matrix3x2.CreateRotation(MathFExtensions.DegreeToRadian(degrees));
 
         /// <summary>
         /// Creates a rotation matrix using the given rotation in radians and a center point.
@@ -91,11 +91,11 @@ namespace SixLabors.Primitives
         public static Matrix3x2 CreateRotation(float radians, PointF centerPoint) => Matrix3x2.CreateRotation(radians, centerPoint);
 
         /// <summary>
-        /// Creates a rotation matrix using the given rotation in radians and a center point.
+        /// Creates a rotation matrix using the given rotation in degrees and a center point.
         /// </summary>
         /// <param name="degrees">The amount of rotation, in degrees.</param>
         /// <param name="centerPoint">The center point.</param>
         /// <returns>A rotation matrix.</returns>
-        public static Matrix3x2 CreateRotationDegrees(float degrees, PointF centerPoint) => Matrix3x2.CreateRotation(MathF.ToRadians(degrees), centerPoint);
+        public static Matrix3x2 CreateRotationDegrees(float degrees, PointF centerPoint) => Matrix3x2.CreateRotation(MathFExtensions.DegreeToRadian(degrees), centerPoint);
     }
 }

--- a/src/SixLabors.Core/SixLabors.Core.csproj
+++ b/src/SixLabors.Core/SixLabors.Core.csproj
@@ -36,7 +36,6 @@
 
     <ItemGroup>
         <AdditionalFiles Include="..\..\stylecop.json" />
-        <Content Include="..\..\stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SixLabors.Core/SixLabors.Core.csproj
+++ b/src/SixLabors.Core/SixLabors.Core.csproj
@@ -1,49 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Low level primitives for use across Six Labors projects..</Description>
-    <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
-    <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha2</VersionPrefix>
-    <Authors>Six Labors</Authors>
-    <TargetFramework>netstandard1.1</TargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>SixLabors.Core</AssemblyName>
-    <PackageId>SixLabors.Core</PackageId>
-    <PackageTags>rectangle;point;size,primitives</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/SixLabors/Home/master/logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/SixLabors/Core</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/SixLabors/Core</RepositoryUrl>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <DebugType Condition="$(codecov) == 'true'">full</DebugType>
-    <RootNamespace>SixLabors</RootNamespace>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Description>Low level primitives for use across Six Labors projects..</Description>
+        <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
+        <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha2</VersionPrefix>
+        <Authors>Six Labors</Authors>
+        <TargetFrameworks>netstandard1.1;netcoreapp2.0;</TargetFrameworks>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <AssemblyName>SixLabors.Core</AssemblyName>
+        <PackageId>SixLabors.Core</PackageId>
+        <PackageTags>rectangle;point;size,primitives</PackageTags>
+        <PackageIconUrl>https://raw.githubusercontent.com/SixLabors/Home/master/logo.png</PackageIconUrl>
+        <PackageProjectUrl>https://github.com/SixLabors/Core</PackageProjectUrl>
+        <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/SixLabors/Core</RepositoryUrl>
+        <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+        <DebugType Condition="$(codecov) == 'true'">full</DebugType>
+        <RootNamespace>SixLabors</RootNamespace>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>..\SixLabors.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+    <PropertyGroup>
+        <CodeAnalysisRuleSet>..\SixLabors.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-    <Content Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
+    <ItemGroup>
+        <AdditionalFiles Include="..\..\stylecop.json" />
+        <Content Include="..\..\stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
 
-  <ItemGroup>
-      <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
-          <PrivateAssets>All</PrivateAssets>
-      </PackageReference>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-  </ItemGroup>
-
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+            <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1'">
+        <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
+    </ItemGroup>
 </Project>

--- a/tests/SixLabors.Core.Tests/Helpers/FloatRoundingComparer.cs
+++ b/tests/SixLabors.Core.Tests/Helpers/FloatRoundingComparer.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace SixLabors.Tests.Helpers
+{
+    /// <summary>
+    /// Allows the comparison of single-precision floating point values by precision.
+    /// </summary>
+    public struct FloatRoundingComparer : IEqualityComparer<float>, IEqualityComparer<Vector4>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FloatRoundingComparer"/> struct.
+        /// </summary>
+        /// <param name="precision">The number of decimal places (valid values: 0-7)</param>
+        public FloatRoundingComparer(int precision)
+        {
+            Guard.MustBeBetweenOrEqualTo(precision, 0, 7, nameof(precision));
+            this.Precision = precision;
+        }
+
+        /// <summary>
+        /// Gets the number of decimal places (valid values: 0-7)
+        /// </summary>
+        public int Precision { get; }
+
+        /// <inheritdoc />
+        public bool Equals(float x, float y)
+        {
+            float xp = (float)Math.Round(x, this.Precision, MidpointRounding.AwayFromZero);
+            float yp = (float)Math.Round(y, this.Precision, MidpointRounding.AwayFromZero);
+
+            return Comparer<float>.Default.Compare(xp, yp) == 0;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(Vector4 x, Vector4 y)
+        {
+            return this.Equals(x.X, y.X) && this.Equals(x.Y, y.Y) && this.Equals(x.Z, y.Z) && this.Equals(x.W, y.W);
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(float obj)
+        {
+            unchecked
+            {
+                int hashCode = obj.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Precision.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(Vector4 obj) => HashHelpers.Combine(obj.GetHashCode(), this.Precision.GetHashCode());
+    }
+}

--- a/tests/SixLabors.Core.Tests/Helpers/MathFTests.cs
+++ b/tests/SixLabors.Core.Tests/Helpers/MathFTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using Xunit;
+
+namespace SixLabors.Tests.Helpers
+{
+    public class MathFTests
+    {
+        [Fact]
+        public void MathF_PI_Is_Equal()
+        {
+            Assert.Equal(MathF.PI, (float)Math.PI);
+        }
+
+        [Fact]
+        public void MathF_Ceililng_Is_Equal()
+        {
+            Assert.Equal(MathF.Ceiling(0.3333F), (float)Math.Ceiling(0.3333F));
+        }
+
+        [Fact]
+        public void MathF_Cos_Is_Equal()
+        {
+            Assert.Equal(MathF.Cos(0.3333F), (float)Math.Cos(0.3333F));
+        }
+
+        [Fact]
+        public void MathF_Abs_Is_Equal()
+        {
+            Assert.Equal(MathF.Abs(-0.3333F), (float)Math.Abs(-0.3333F));
+        }
+
+        [Fact]
+        public void MathF_Atan2_Is_Equal()
+        {
+            Assert.Equal(MathF.Atan2(1.2345F, 1.2345F), (float)Math.Atan2(1.2345F, 1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Exp_Is_Equal()
+        {
+            Assert.Equal(MathF.Exp(1.2345F), (float)Math.Exp(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Floor_Is_Equal()
+        {
+            Assert.Equal(MathF.Floor(1.2345F), (float)Math.Floor(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Min_Is_Equal()
+        {
+            Assert.Equal(MathF.Min(1.2345F, 5.4321F), (float)Math.Min(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Max_Is_Equal()
+        {
+            Assert.Equal(MathF.Max(1.2345F, 5.4321F), (float)Math.Max(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Pow_Is_Equal()
+        {
+            Assert.Equal(MathF.Pow(1.2345F, 5.4321F), (float)Math.Pow(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Round_Is_Equal()
+        {
+            Assert.Equal(MathF.Round(1.2345F), (float)Math.Round(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Round_With_Midpoint_Is_Equal()
+        {
+            Assert.Equal(MathF.Round(1.2345F, MidpointRounding.AwayFromZero), (float)Math.Round(1.2345F, MidpointRounding.AwayFromZero));
+        }
+
+        [Fact]
+        public void MathF_Sin_Is_Equal()
+        {
+            Assert.Equal(MathF.Sin(1.2345F), (float)Math.Sin(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Sqrt_Is_Equal()
+        {
+            Assert.Equal(MathF.Sqrt(2F), (float)Math.Sqrt(2F));
+        }
+
+        [Fact]
+        public void Convert_Degree_To_Radian()
+        {
+            Assert.Equal((float)(Math.PI / 2D), MathFExtensions.DegreeToRadian(90F), new FloatRoundingComparer(6));
+        }
+
+        [Fact]
+        public void Convert_Radian_To_Degree()
+        {
+            Assert.Equal(60F, MathFExtensions.RadianToDegree((float)(Math.PI / 3D)), new FloatRoundingComparer(5));
+        }
+    }
+}

--- a/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Globalization;
 using System.Numerics;
 using Xunit;

--- a/tests/SixLabors.Core.Tests/SixLabors.Core.Tests.csproj
+++ b/tests/SixLabors.Core.Tests/SixLabors.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;</TargetFrameworks>
     <AssemblyName>SixLabors.Core.Tests</AssemblyName>
     <PackageId>SixLabors.Shapes.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
This PR adds a new .NET Core 2.0 build target so we can take advantage of the new optimized `MathF` methods available there. In order to do so I had to move our `MathF` class to the `System` namespace

I've also removed unused methods and moved the Degree/Radian conversions to a new `MathFExtensions` class as they cannot stay within the `System.MathF` class as it would cause ambiguous references.

We'll have to update our other libraries to use the new namespace.