### PR TITLE
Replace skew and rotate with single transform

### DIFF
--- a/src/SixLabors.Core/Primitives/Point.cs
+++ b/src/SixLabors.Core/Primitives/Point.cs
@@ -233,16 +233,7 @@ namespace SixLabors.Primitives
         /// <param name="matrix">The transformation matrix used</param>
         /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Point Transform(Point point, Matrix3x2 matrix) => Transform(new Vector2(point.X, point.Y), matrix);
-
-        /// <summary>
-        /// Transforms a vector by a specified 3x2 matrix.
-        /// </summary>
-        /// <param name="position">The vector to transform</param>
-        /// <param name="matrix">The transformation matrix used</param>
-        /// <returns>The transformed <see cref="PointF"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Point Transform(Vector2 position, Matrix3x2 matrix) => Round(Vector2.Transform(position, matrix));
+        public static Point Transform(Point point, Matrix3x2 matrix) => Round(Vector2.Transform(new Vector2(point.X, point.Y), matrix));
 
         /// <summary>
         /// Translates this <see cref="Point"/> by the specified amount.

--- a/src/SixLabors.Core/Primitives/Point.cs
+++ b/src/SixLabors.Core/Primitives/Point.cs
@@ -211,15 +211,12 @@ namespace SixLabors.Primitives
         public static Point Round(PointF point) => new Point(unchecked((int)MathF.Round(point.X)), unchecked((int)MathF.Round(point.Y)));
 
         /// <summary>
-        /// Transforms a point by the given matrix.
+        /// Converts a <see cref="Vector2"/> to a <see cref="Point"/> by performing a round operation on all the coordinates.
         /// </summary>
-        /// <param name="position">The source point.</param>
-        /// <param name="matrix">The transformation matrix.</param>
-        /// <returns>A transformed point.</returns>
-        public static PointF Transform(Point position, Matrix3x2 matrix)
-        {
-            return Vector2.Transform(position, matrix);
-        }
+        /// <param name="vector">The vector</param>
+        /// <returns>The <see cref="Point"/></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Point Round(Vector2 vector) => new Point(unchecked((int)MathF.Round(vector.X)), unchecked((int)MathF.Round(vector.Y)));
 
         /// <summary>
         /// Converts a <see cref="PointF"/> to a <see cref="Point"/> by performing a truncate operation on all the coordinates.
@@ -230,30 +227,22 @@ namespace SixLabors.Primitives
         public static Point Truncate(PointF point) => new Point(unchecked((int)point.X), unchecked((int)point.Y));
 
         /// <summary>
-        /// Converts a <see cref="Vector2"/> to a <see cref="Point"/> by performing a round operation on all the coordinates.
+        /// Transforms a point by a specified 3x2 matrix.
         /// </summary>
-        /// <param name="vector">The vector</param>
-        /// <returns>The <see cref="Point"/></returns>
+        /// <param name="point">The point to transform</param>
+        /// <param name="matrix">The transformation matrix used</param>
+        /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Point Round(Vector2 vector) => new Point(unchecked((int)MathF.Round(vector.X)), unchecked((int)MathF.Round(vector.Y)));
+        public static Point Transform(Point point, Matrix3x2 matrix) => Transform(new Vector2(point.X, point.Y), matrix);
 
         /// <summary>
-        /// Rotates a point around the given rotation matrix.
+        /// Transforms a vector by a specified 3x2 matrix.
         /// </summary>
-        /// <param name="point">The point to rotate</param>
-        /// <param name="rotation">Rotation matrix used</param>
-        /// <returns>The rotated <see cref="Point"/></returns>
+        /// <param name="position">The vector to transform</param>
+        /// <param name="matrix">The transformation matrix used</param>
+        /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Point Rotate(Point point, Matrix3x2 rotation) => Round(Vector2.Transform(new Vector2(point.X, point.Y), rotation));
-
-        /// <summary>
-        /// Skews a point using the given skew matrix.
-        /// </summary>
-        /// <param name="point">The point to rotate</param>
-        /// <param name="skew">Rotation matrix used</param>
-        /// <returns>The rotated <see cref="Point"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Point Skew(Point point, Matrix3x2 skew) => Round(Vector2.Transform(new Vector2(point.X, point.Y), skew));
+        public static Point Transform(Vector2 position, Matrix3x2 matrix) => Round(Vector2.Transform(position, matrix));
 
         /// <summary>
         /// Translates this <see cref="Point"/> by the specified amount.

--- a/src/SixLabors.Core/Primitives/PointF.cs
+++ b/src/SixLabors.Core/Primitives/PointF.cs
@@ -238,34 +238,14 @@ namespace SixLabors.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static PointF Multiply(PointF point, float right) => new PointF(point.X * right, point.Y * right);
 
-        /// <summary>PointF
-        /// Rotates a point around the given rotation matrix.
-        /// </summary>
-        /// <param name="point">The point to rotate</param>
-        /// <param name="rotation">Rotation matrix used</param>
-        /// <returns>The rotated <see cref="PointF"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PointF Rotate(PointF point, Matrix3x2 rotation) => Vector2.Transform(new Vector2(point.X, point.Y), rotation);
-
         /// <summary>
-        /// Skews a point using the given skew matrix.
+        /// Transforms a point by a specified 3x2 matrix.
         /// </summary>
-        /// <param name="point">The point to rotate</param>
-        /// <param name="skew">Rotation matrix used</param>
-        /// <returns>The rotated <see cref="PointF"/></returns>
+        /// <param name="point">The point to transform</param>
+        /// <param name="matrix">The transformation matrix used</param>
+        /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PointF Skew(PointF point, Matrix3x2 skew) => Vector2.Transform(new Vector2(point.X, point.Y), skew);
-
-        /// <summary>
-        /// Transforms a point by the given matrix.
-        /// </summary>
-        /// <param name="position">The source point.</param>
-        /// <param name="matrix">The transformation matrix.</param>
-        /// <returns>A transformed point.</returns>
-        public static PointF Transform(PointF position, Matrix3x2 matrix)
-        {
-            return Vector2.Transform(position, matrix);
-        }
+        public static PointF Transform(PointF point, Matrix3x2 matrix) => Vector2.Transform(point, matrix);
 
         /// <summary>
         /// Translates this <see cref="PointF"/> by the specified amount.

--- a/src/SixLabors.Core/Primitives/RectangleF.cs
+++ b/src/SixLabors.Core/Primitives/RectangleF.cs
@@ -254,7 +254,7 @@ namespace SixLabors.Primitives
         /// </summary>
         /// <param name="rectangle">The source rectangle.</param>
         /// <param name="matrix">The transformation matrix.</param>
-        /// <returns>A transformed rectangle.</returns>
+        /// <returns>A transformed <see cref="RectangleF"/>.</returns>
         public static RectangleF Transform(RectangleF rectangle, Matrix3x2 matrix)
         {
             PointF bottomRight = PointF.Transform(new PointF(rectangle.Right, rectangle.Bottom), matrix);

--- a/tests/SixLabors.Core.Tests/Primitives/PointFTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/PointFTests.cs
@@ -106,7 +106,7 @@ namespace SixLabors.Primitives.Tests
             var p = new PointF(13, 17);
             Matrix3x2 matrix = Matrix3x2Extensions.CreateRotationDegrees(45, PointF.Empty);
 
-            var pout = PointF.Rotate(p, matrix);
+            var pout = PointF.Transform(p, matrix);
 
             Assert.Equal(new PointF(-2.82842732F, 21.2132034F), pout);
         }
@@ -117,7 +117,7 @@ namespace SixLabors.Primitives.Tests
             var p = new PointF(13, 17);
             Matrix3x2 matrix = Matrix3x2Extensions.CreateSkewDegrees(45, 45, PointF.Empty);
 
-            var pout = PointF.Skew(p, matrix);
+            var pout = PointF.Transform(p, matrix);
             Assert.Equal(new PointF(30, 30), pout);
         }
 

--- a/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
@@ -161,7 +161,7 @@ namespace SixLabors.Primitives.Tests
             var p = new Point(13, 17);
             Matrix3x2 matrix = Matrix3x2Extensions.CreateRotationDegrees(45, Point.Empty);
 
-            var pout = Point.Rotate(p, matrix);
+            var pout = Point.Transform(p, matrix);
 
             Assert.Equal(new Point(-3, 21), pout);
         }
@@ -172,7 +172,7 @@ namespace SixLabors.Primitives.Tests
             var p = new Point(13, 17);
             Matrix3x2 matrix = Matrix3x2Extensions.CreateSkewDegrees(45, 45, Point.Empty);
 
-            var pout = Point.Skew(p, matrix);
+            var pout = Point.Transform(p, matrix);
             Assert.Equal(new Point(30, 30), pout);
         }
 


### PR DESCRIPTION
Relates to https://github.com/SixLabors/ImageSharp/pull/386#pullrequestreview-78815265

Both `Skew` and `Rotate` on the `Point` struct have identical signatures with identical method bodies. 

This PR simplifies this by utilizing a single `Transform` method with the same signature as the `Vector2` equivalent. (I decided not to go `ref` for consistancy).

This allows us to turn `AffineProcessor` in my ImageSharp PR into a single base class that can handle any kind of transform. I believe to developers this also provides greater consistency across `Point`, `PointF`, and `Vector2`