### PR TITLE
Cross target netstandard2.0

### DIFF
--- a/src/SixLabors.Core/SixLabors.Core.csproj
+++ b/src/SixLabors.Core/SixLabors.Core.csproj
@@ -5,7 +5,7 @@
         <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
         <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha2</VersionPrefix>
         <Authors>Six Labors</Authors>
-        <TargetFrameworks>netstandard1.1;netcoreapp2.0;netcoreapp2.1;</TargetFrameworks>
+        <TargetFrameworks>netstandard1.1;netstandard2.0;netcoreapp2.0;netcoreapp2.1;</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AssemblyName>SixLabors.Core</AssemblyName>
@@ -45,8 +45,8 @@
         <PackageReference Include="System.Buffers" Version="4.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.1" />
     </ItemGroup>
-  
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-        <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+      <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
We need to cross target netstandard2.0 to keep the dependency graph simple on modern runtimes.