### PR TITLE
Added deconstructors to the primitives

### DIFF
--- a/src/SixLabors.Core/Primitives/Point.cs
+++ b/src/SixLabors.Core/Primitives/Point.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -234,6 +234,17 @@ namespace SixLabors.Primitives
         /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Point Transform(Point point, Matrix3x2 matrix) => Round(Vector2.Transform(new Vector2(point.X, point.Y), matrix));
+
+        /// <summary>
+        /// Deconstructs this point into two integers
+        /// </summary>
+        /// <param name="x">The out value for X</param>
+        /// <param name="y">The out value for Y</param>
+        public void Deconstruct(out int x, out int y)
+        {
+            x = this.X;
+            y = this.Y;
+        }
 
         /// <summary>
         /// Translates this <see cref="Point"/> by the specified amount.

--- a/src/SixLabors.Core/Primitives/PointF.cs
+++ b/src/SixLabors.Core/Primitives/PointF.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -246,6 +246,17 @@ namespace SixLabors.Primitives
         /// <returns>The transformed <see cref="PointF"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static PointF Transform(PointF point, Matrix3x2 matrix) => Vector2.Transform(point, matrix);
+
+        /// <summary>
+        /// Deconstructs this point into two floats
+        /// </summary>
+        /// <param name="x">The out value for X</param>
+        /// <param name="y">The out value for Y</param>
+        public void Deconstruct(out float x, out float y)
+        {
+            x = this.X;
+            y = this.Y;
+        }
 
         /// <summary>
         /// Translates this <see cref="PointF"/> by the specified amount.

--- a/src/SixLabors.Core/Primitives/Rectangle.cs
+++ b/src/SixLabors.Core/Primitives/Rectangle.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -318,6 +318,21 @@ namespace SixLabors.Primitives
             int y2 = Math.Max(a.Bottom, b.Bottom);
 
             return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+        }
+
+        /// <summary>
+        /// Deconstructs this rectangle into four integers
+        /// </summary>
+        /// <param name="x">The out value for X</param>
+        /// <param name="y">The out value for Y</param>
+        /// <param name="width">The out value for the width</param>
+        /// <param name="height">The out value for the height</param>
+        public void Deconstruct(out int x, out int y, out int width, out int height)
+        {
+            x = this.X;
+            y = this.Y;
+            width = this.Width;
+            height = this.Height;
         }
 
         /// <summary>

--- a/src/SixLabors.Core/Primitives/RectangleF.cs
+++ b/src/SixLabors.Core/Primitives/RectangleF.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -257,6 +257,21 @@ namespace SixLabors.Primitives
             float y2 = MathF.Max(a.Bottom, b.Bottom);
 
             return new RectangleF(x1, y1, x2 - x1, y2 - y1);
+        }
+
+        /// <summary>
+        /// Deconstructs this rectangle into four floats
+        /// </summary>
+        /// <param name="x">The out value for X</param>
+        /// <param name="y">The out value for Y</param>
+        /// <param name="width">The out value for the width</param>
+        /// <param name="height">The out value for the height</param>
+        public void Deconstruct(out float x, out float y, out float width, out float height)
+        {
+            x = this.X;
+            y = this.Y;
+            width = this.Width;
+            height = this.Height;
         }
 
         /// <summary>

--- a/src/SixLabors.Core/Primitives/Size.cs
+++ b/src/SixLabors.Core/Primitives/Size.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -250,6 +250,17 @@ namespace SixLabors.Primitives
         /// <returns>The <see cref="Size"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Size Truncate(SizeF size) => new Size(unchecked((int)size.Width), unchecked((int)size.Height));
+
+        /// <summary>
+        /// Deconstructs this size into two integers
+        /// </summary>
+        /// <param name="width">The out value for the width</param>
+        /// <param name="height">The out value for the height</param>
+        public void Deconstruct(out int width, out int height)
+        {
+            width = this.Width;
+            height = this.Height;
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Combine(this.Width, this.Height);

--- a/src/SixLabors.Core/Primitives/SizeF.cs
+++ b/src/SixLabors.Core/Primitives/SizeF.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -195,6 +195,17 @@ namespace SixLabors.Primitives
             var v = Vector2.Transform(new Vector2(size.Width, size.Height), matrix);
 
             return new SizeF(v.X, v.Y);
+        }
+
+        /// <summary>
+        /// Deconstructs this size into two floats
+        /// </summary>
+        /// <param name="width">The out value for the width</param>
+        /// <param name="height">The out value for the height</param>
+        public void Deconstruct(out float width, out float height)
+        {
+            width = this.Width;
+            height = this.Height;
         }
 
         /// <inheritdoc/>

--- a/tests/SixLabors.Core.Tests/Primitives/PointFTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/PointFTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -190,6 +190,21 @@ namespace SixLabors.Primitives.Tests
         {
             var p = new PointF(5.1F, -5.123F);
             Assert.Equal(string.Format(CultureInfo.CurrentCulture, "PointF [ X={0}, Y={1} ]", p.X, p.Y), p.ToString());
+        }
+
+        [Theory]
+        [InlineData(float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue)]
+        [InlineData(0, 0)]
+        public void DeconstructTest(float x, float y)
+        {
+            PointF p = new PointF(x, y);
+
+            (float deconstructedX, float deconstructedY) = p;
+
+            Assert.Equal(x, deconstructedX);
+            Assert.Equal(y, deconstructedY);
         }
     }
 }

--- a/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/PointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -238,6 +238,21 @@ namespace SixLabors.Primitives.Tests
         {
             var p = new Point(5, -5);
             Assert.Equal(string.Format(CultureInfo.CurrentCulture, "Point [ X={0}, Y={1} ]", p.X, p.Y), p.ToString());
+        }
+
+        [Theory]
+        [InlineData(int.MaxValue, int.MinValue)]
+        [InlineData(int.MinValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MaxValue)]
+        [InlineData(0, 0)]
+        public void DeconstructTest(int x, int y)
+        {
+            Point p = new Point(x, y);
+
+            (int deconstructedX, int deconstructedY) = p;
+
+            Assert.Equal(x, deconstructedX);
+            Assert.Equal(y, deconstructedY);
         }
     }
 }

--- a/tests/SixLabors.Core.Tests/Primitives/RectangleFTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/RectangleFTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -251,6 +251,36 @@ namespace SixLabors.Primitives.Tests
         {
             var r = new RectangleF(5, 5.1F, 1.3F, 1);
             Assert.Equal(string.Format(CultureInfo.CurrentCulture, "RectangleF [ X={0}, Y={1}, Width={2}, Height={3} ]", r.X, r.Y, r.Width, r.Height), r.ToString());
+        }
+
+        [Theory]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MinValue, float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MaxValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue, float.MinValue)]
+        [InlineData(0, 0, 0, 0)]
+        public void DeconstructTest(float x, float y, float width, float height)
+        {
+            RectangleF r = new RectangleF(x, y, width, height);
+
+            (float dx, float dy, float dw, float dh) = r;
+
+            Assert.Equal(x, dx);
+            Assert.Equal(y, dy);
+            Assert.Equal(width, dw);
+            Assert.Equal(height, dh);
         }
     }
 }

--- a/tests/SixLabors.Core.Tests/Primitives/RectangleTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/RectangleTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -293,6 +293,36 @@ namespace SixLabors.Primitives.Tests
         {
             var r = new Rectangle(5, -5, 0, 1);
             Assert.Equal(string.Format(CultureInfo.CurrentCulture, "Rectangle [ X={0}, Y={1}, Width={2}, Height={3} ]", r.X, r.Y, r.Width, r.Height), r.ToString());
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, int.MaxValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MinValue, int.MaxValue, int.MaxValue, int.MinValue)]
+        [InlineData(int.MinValue, int.MaxValue, int.MinValue, int.MaxValue)]
+        [InlineData(int.MinValue, int.MaxValue, int.MinValue, int.MinValue)]
+        [InlineData(int.MinValue, int.MinValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MinValue, int.MinValue, int.MaxValue, int.MinValue)]
+        [InlineData(int.MinValue, int.MinValue, int.MinValue, int.MaxValue)]
+        [InlineData(int.MinValue, int.MinValue, int.MinValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MinValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MinValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MinValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MinValue, int.MaxValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MinValue, int.MinValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MinValue, int.MinValue, int.MinValue)]
+        [InlineData(0, 0, 0, 0)]
+        public void DeconstructTest(int x, int y, int width, int height)
+        {
+            Rectangle r = new Rectangle(x, y, width, height);
+
+            (int dx, int dy, int dw, int dh) = r;
+
+            Assert.Equal(x, dx);
+            Assert.Equal(y, dy);
+            Assert.Equal(width, dw);
+            Assert.Equal(height, dh);
         }
     }
 }

--- a/tests/SixLabors.Core.Tests/Primitives/SizeFTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/SizeFTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -230,6 +230,21 @@ namespace SixLabors.Primitives.Tests
             SizeF size = new SizeF(width, height);
             SizeF expected = new SizeF(width / divisor, height / divisor);
             Assert.Equal(expected, size / divisor);
+        }
+
+        [Theory]
+        [InlineData(float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue)]
+        [InlineData(0, 0)]
+        public void DeconstructTest(float width, float height)
+        {
+            SizeF s = new SizeF(width, height);
+
+            (float deconstructedWidth, float deconstructedHeight) = s;
+
+            Assert.Equal(width, deconstructedWidth);
+            Assert.Equal(height, deconstructedHeight);
         }
     }
 }

--- a/tests/SixLabors.Core.Tests/Primitives/SizeTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/SizeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -359,6 +359,21 @@ namespace SixLabors.Primitives.Tests
 
             expected = new SizeF(width / divisor, height / divisor);
             Assert.Equal(expected, size / divisor);
+        }
+
+        [Theory]
+        [InlineData(int.MaxValue, int.MinValue)]
+        [InlineData(int.MinValue, int.MinValue)]
+        [InlineData(int.MaxValue, int.MaxValue)]
+        [InlineData(0, 0)]
+        public void DeconstructTest(int width, int height)
+        {
+            Size s = new Size(width, height);
+
+            (int deconstructedWidth, int deconstructedHeight) = s;
+
+            Assert.Equal(width, deconstructedWidth);
+            Assert.Equal(height, deconstructedHeight);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
I added deconstructors to the primitives. I was trying to use ImageSharp for a project, and when using the mutate function I already had a variable named `size`. 

So then I wanted to use a deconstructor and I tried: 

    var (width, height) = ctx.GetCurrentSize(); 

This proofed not possible since there were no deconstructors, so I thought I write a few.

With this PR the above code will work, and makes imagesharp a bit more usable :)