### PR TITLE
Changed duplicate InlineData from MinValue to MaxValue

### DIFF
--- a/tests/SixLabors.Core.Tests/Primitives/SizeFTests.cs
+++ b/tests/SixLabors.Core.Tests/Primitives/SizeFTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -213,9 +213,9 @@ namespace SixLabors.Primitives.Tests
         [InlineData(float.MinValue, -1.0f)]
         [InlineData(float.MinValue, 0.0f)]
         [InlineData(1.0f, float.MinValue)]
-        [InlineData(1.0f, float.MinValue)]
+        [InlineData(1.0f, float.MaxValue)]
         [InlineData(-1.0f, float.MinValue)]
-        [InlineData(-1.0f, float.MinValue)]
+        [InlineData(-1.0f, float.MaxValue)]
         public void DivideTestSizeFloat(float dimension, float divisor)
         {
             SizeF size = new SizeF(dimension, dimension);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Core/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
One of the tests for `SizeF` called `DivideTestSizeFloat` contained duplicate `InlineData`:

    [InlineData(1.0f, float.MinValue)]
    [InlineData(1.0f, float.MinValue)]
    [InlineData(-1.0f, float.MinValue)]
    [InlineData(-1.0f, float.MinValue)]

I changed the duplicates to use `float.MaxValue`, what I believe was the original intent.