### PR TITLE
Added .github folder based upon ImageSharp .github folder.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# How to contribute to SixLabors.Core
+
+#### **Did you find a bug?**
+
+- Please **ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/SixLabors/Core/issues).
+
+- If you're unable to find an open issue addressing the problem, please [open a new one](https://github.com/SixLabors/Core/issues/new). Be sure to include a **title, the applicable version, a clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring. Please do not hijack existing issues.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+* Before submitting, please ensure that your code matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
+
+#### **Do you intend to add a new feature or change an existing one?**
+
+* Suggest your change in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General) and start writing code.
+
+* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+
+#### **Running tests and Debugging**
+
+* Debugging (running tests in Debug mode) is only supported on .NET Core 2.1, because of JIT Code Generation bugs like [dotnet/coreclr#16443](https://github.com/dotnet/coreclr/issues/16443) or [dotnet/coreclr#20657](https://github.com/dotnet/coreclr/issues/20657)
+
+#### **Do you have questions about consuming the library or the source code?**
+
+* Ask any question about how to use SixLabors.Core in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General).
+
+And please remember. SixLabors.Core is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible imageprocessing available to all. Open Source can only exist with your help.
+
+Thanks for reading!
+
+James Jackson-South :heart:

--- a/.github/ISSUE_TEMPLATE/ask-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-question.md
@@ -1,0 +1,13 @@
+---
+name: Ask question
+about: Ask a question about this project.
+
+---
+
+You should not create an issue but use Gitter instead: https://gitter.im/ImageSharp/General
+
+You should not create an issue but use Gitter instead: https://gitter.im/ImageSharp/General
+
+You should not create an issue but use Gitter instead: https://gitter.im/ImageSharp/General
+
+You should not create an issue but use Gitter instead: https://gitter.im/ImageSharp/General

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+### Prerequisites
+
+- [ ] I have written a descriptive issue title
+- [ ] I have verified that I am running the latest version of ImageSharp
+- [ ] I have verified if the problem exist in both `DEBUG` and `RELEASE` mode
+- [ ] I have searched [open](https://github.com/SixLabors/Core/issues) and [closed](https://github.com/SixLabors/Core/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported
+
+### Description
+<!-- A description of the bug or feature -->
+
+### Steps to Reproduce
+<!-- List of steps, sample code, failing test or link to a project that reproduces the behavior -->
+
+### System Configuration
+<!-- Tell us about the environment where you are experiencing the bug -->
+
+- SixLabors.Core version:
+- Other SixLabors packages and versions:
+- Environment (Operating system, version and so on):
+- .NET Framework version:
+- Additional information:
+
+<!-- Thanks for reporting the issue to SixLabors.Core! -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+You should first discuss the feature on Gitter: https://gitter.im/ImageSharp/General
+
+You should first discuss the feature on Gitter: https://gitter.im/ImageSharp/General
+
+You should first discuss the feature on Gitter: https://gitter.im/ImageSharp/General
+
+You should first discuss the feature on Gitter: https://gitter.im/ImageSharp/General

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Prerequisites
+
+- [ ] I have written a descriptive pull-request title
+- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Core/pulls) open
+- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
+- [ ] I have provided test coverage for my change (where applicable)
+
+### Description
+<!-- A description of the changes proposed in the pull-request -->
+
+<!-- Thanks for contributing to ImageSharp! -->

--- a/SixLabors.Core.sln
+++ b/SixLabors.Core.sln
@@ -1,15 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
+		.github\ISSUE_TEMPLATE\ask-question.md = .github\ISSUE_TEMPLATE\ask-question.md
+		.github\ISSUE_TEMPLATE\bug-report.md = .github\ISSUE_TEMPLATE\bug-report.md
 		build.cmd = build.cmd
 		codecov.yml = codecov.yml
+		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\ISSUE_TEMPLATE\feature-request.md = .github\ISSUE_TEMPLATE\feature-request.md
 		gitversion.yml = gitversion.yml
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -48,6 +53,9 @@ Global
 		{09E744EC-4852-4FC7-BE78-C1B399F17967} = {815C0625-CD3D-440F-9F80-2D83856AB7AE}
 		{F836E8E6-B4D9-4208-8346-140C74678B91} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 		{10A74B46-930F-49E3-A579-BC3A6A23321D} = {C317F1B1-D75E-4C6D-83EB-80367343E0D7}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0DED1AC8-37DA-4EC2-8CAE-40E31CD439DE}
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Core/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Because @JimBobSquarePants said he didn't see my PR for contributing guidelines in #27, I thought why not make the PR. So here it is.

#### Things done:
- I copied the `.github` folder from ImageSharp
- Included the files in the solution just like in ImageSharp
  - _I just saw this also changed the solution file version since I used VS2019_
- Changed all urls from ImageSharp repo to Core repo
- Changed mentions of ImageSharp to SixLabors.Core
  - _Just Core seemed weired to me._
- Left all the gitter urls towards ImageSharp since I could not find a Gitter channel for SixLabors.Core
- In `CONTRIBUTING.md` I removed the mention of the images submodule.
- IN `bug-report.md` I changed the **System Configuration** to mention Core and other SixLabors packages instead of just ImageSharp.